### PR TITLE
Egg: punch as the throwing player

### DIFF
--- a/chicken.lua
+++ b/chicken.lua
@@ -113,14 +113,14 @@ mobs:register_arrow("mobs_animal:egg_entity", {
 	velocity = 6,
 
 	hit_player = function(self, player)
-		player:punch(self.object, 1.0, {
+		player:punch(minetest.get_player_by_name(self.playername) or self.object, 1.0, {
 			full_punch_interval = 1.0,
 			damage_groups = {fleshy = 1},
 		}, nil)
 	end,
 
 	hit_mob = function(self, player)
-		player:punch(self.object, 1.0, {
+		player:punch(minetest.get_player_by_name(self.playername) or self.object, 1.0, {
 			full_punch_interval = 1.0,
 			damage_groups = {fleshy = 1},
 		}, nil)


### PR DESCRIPTION
Useful for `register_on_punchplayer` callbacks (e.g., [the one in the PvPPlus mod](https://github.com/Mynetest/pvpplus/blob/954ce04b2117d29bde17dd0de8dd6116e0fe04f9/functions.lua#L118))